### PR TITLE
fix serializers/deserializers #82

### DIFF
--- a/src/main/java/javaslang/jackson/datatype/JavaslangTypeModifier.java
+++ b/src/main/java/javaslang/jackson/datatype/JavaslangTypeModifier.java
@@ -15,11 +15,12 @@ public class JavaslangTypeModifier extends TypeModifier {
         if (type.isReferenceType() || type.isContainerType()) {
             return type;
         }
-
         final Class<?> raw = type.getRawClass();
-        if (raw == List.class) {
-            return CollectionLikeType.construct(
-                raw, type.containedTypeOrUnknown(0));
+        if (Seq.class.isAssignableFrom(raw) && CharSeq.class != raw) {
+            return CollectionLikeType.construct(raw, type.containedTypeOrUnknown(0));
+        }
+        if (Set.class.isAssignableFrom(raw)) {
+            return CollectionLikeType.construct(raw, type.containedTypeOrUnknown(0));
         }
         return type;
     }

--- a/src/main/java/javaslang/jackson/datatype/deserialize/JavaslangDeserializers.java
+++ b/src/main/java/javaslang/jackson/datatype/deserialize/JavaslangDeserializers.java
@@ -17,6 +17,8 @@ package javaslang.jackson.datatype.deserialize;
 
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.deser.Deserializers;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
 import javaslang.Lazy;
 import javaslang.Tuple;
 import javaslang.collection.*;
@@ -62,17 +64,26 @@ public class JavaslangDeserializers extends Deserializers.Base {
         if (Tuple.class.isAssignableFrom(raw)) {
             return new TupleDeserializer(type);
         }
+        if (λ.class.isAssignableFrom(raw)) {
+            return new SerializableDeserializer<>(type);
+        }
+
+        return super.findBeanDeserializer(type, config, beanDesc);
+    }
+
+    @Override
+    public JsonDeserializer<?> findCollectionLikeDeserializer(CollectionLikeType type,
+                                                              DeserializationConfig config, BeanDescription beanDesc,
+                                                              TypeDeserializer elementTypeDeserializer, JsonDeserializer<?> elementDeserializer)
+            throws JsonMappingException
+    {
+        Class<?> raw = type.getRawClass();
         if (Seq.class.isAssignableFrom(raw)) {
             return new SeqDeserializer(type, settings.deserializeNullAsEmptyCollection());
         }
         if (Set.class.isAssignableFrom(raw)) {
             return new SetDeserializer(type, settings.deserializeNullAsEmptyCollection());
         }
-
-        if (λ.class.isAssignableFrom(raw)) {
-            return new SerializableDeserializer<>(type);
-        }
-
-        return null;
+        return super.findCollectionLikeDeserializer(type, config, beanDesc, elementTypeDeserializer, elementDeserializer);
     }
 }

--- a/src/main/java/javaslang/jackson/datatype/serialize/JavaslangSerializers.java
+++ b/src/main/java/javaslang/jackson/datatype/serialize/JavaslangSerializers.java
@@ -19,7 +19,9 @@ import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.ser.Serializers;
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
 import javaslang.Lazy;
 import javaslang.Tuple;
 import javaslang.collection.*;
@@ -56,12 +58,6 @@ public class JavaslangSerializers extends Serializers.Base {
         if (PriorityQueue.class.isAssignableFrom(raw)) {
             return new ArraySerializer<>(type);
         }
-        if (Seq.class.isAssignableFrom(raw)) {
-            return new ArraySerializer<>(type);
-        }
-        if (Set.class.isAssignableFrom(raw)) {
-            return new ArraySerializer<>(type);
-        }
         if (Map.class.isAssignableFrom(raw)) {
             return new MapSerializer(type);
         }
@@ -77,5 +73,19 @@ public class JavaslangSerializers extends Serializers.Base {
         }
 
         return super.findSerializer(config, type, beanDesc);
+    }
+
+    @Override
+    public JsonSerializer<?> findCollectionLikeSerializer(SerializationConfig config,
+                                                          CollectionLikeType type, BeanDescription beanDesc,
+                                                          TypeSerializer elementTypeSerializer, JsonSerializer<Object> elementValueSerializer) {
+        Class<?> raw = type.getRawClass();
+        if (Seq.class.isAssignableFrom(raw)) {
+            return new ArraySerializer<>(type);
+        }
+        if (Set.class.isAssignableFrom(raw)) {
+            return new ArraySerializer<>(type);
+        }
+        return super.findCollectionLikeSerializer(config, type, beanDesc, elementTypeSerializer, elementValueSerializer);
     }
 }


### PR DESCRIPTION
Now we have only one failed test:

```
Failed tests: 
  ListTest.testXmlSerialization:98 
expected:<<XmlSerializeJava[Util xmlns=""><transitTypes><transitType>1</transitType><transitType>2</transitType><transitType>3</transitType></transitTypes></XmlSerializeJavaUtil]>> 
 but was:<<XmlSerializeJava[slang xmlns=""><transitTypes><transitType>1</transitType><transitType>2</transitType><transitType>3</transitType></transitTypes></XmlSerializeJavaslang]>>
```

Please take a look
